### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/autogen-agent-workflow-patterns/poetry.lock
+++ b/autogen-agent-workflow-patterns/poetry.lock
@@ -396,14 +396,14 @@ files = [
 ]
 
 [[package]]
-name = "pyautogen"
+name = "ag2"
 version = "0.2.28"
 description = "Enabling Next-Gen LLM Applications via Multi-Agent Conversation Framework"
 optional = false
 python-versions = "<3.13,>=3.8"
 files = [
-    {file = "pyautogen-0.2.28-py3-none-any.whl", hash = "sha256:69dffa4053096f496a50c8a252bbe23105b58fd6ffbb422fa8c043ecf3fc732b"},
-    {file = "pyautogen-0.2.28.tar.gz", hash = "sha256:f74686a981f2b6046a9cf6aff5a5e61615ec60d5559a49e7474467fbdf4e077b"},
+    {file = "ag2-0.2.28-py3-none-any.whl", hash = "sha256:69dffa4053096f496a50c8a252bbe23105b58fd6ffbb422fa8c043ecf3fc732b"},
+    {file = "ag2-0.2.28.tar.gz", hash = "sha256:f74686a981f2b6046a9cf6aff5a5e61615ec60d5559a49e7474467fbdf4e077b"},
 ]
 
 [package.dependencies]

--- a/autogen-agent-workflow-patterns/pyproject.toml
+++ b/autogen-agent-workflow-patterns/pyproject.toml
@@ -11,7 +11,7 @@ two-agent = "workflow_patterns.two_agent.main:main"
 
 [tool.poetry.dependencies]
 python = "~3.10"
-pyautogen = "^0.2.28"
+ag2 = "^0.2.28"
 
 
 [build-system]

--- a/autogen-k8s-basic/poetry.lock
+++ b/autogen-k8s-basic/poetry.lock
@@ -642,14 +642,14 @@ files = [
 pyasn1 = ">=0.4.6,<0.6.0"
 
 [[package]]
-name = "pyautogen"
+name = "ag2"
 version = "0.1.14"
 description = "Enabling Next-Gen LLM Applications via Multi-Agent Conversation Framework"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyautogen-0.1.14-py3-none-any.whl", hash = "sha256:4f12b248af5350958a6073952123a802334b3d3dcd700353cdf25a8aacac4298"},
-    {file = "pyautogen-0.1.14.tar.gz", hash = "sha256:1e9334cc7a69e73907154ff7c9c323f13aab7b70bdc8cce836be7ea92a127fff"},
+    {file = "ag2-0.1.14-py3-none-any.whl", hash = "sha256:4f12b248af5350958a6073952123a802334b3d3dcd700353cdf25a8aacac4298"},
+    {file = "ag2-0.1.14.tar.gz", hash = "sha256:1e9334cc7a69e73907154ff7c9c323f13aab7b70bdc8cce836be7ea92a127fff"},
 ]
 
 [package.dependencies]

--- a/autogen-k8s-basic/pyproject.toml
+++ b/autogen-k8s-basic/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.11"
-pyautogen = "^0.1.14"
+ag2 = "^0.1.14"
 kubernetes = "^28.1.0"
 
 [build-system]

--- a/autogen-workflows/poetry.lock
+++ b/autogen-workflows/poetry.lock
@@ -467,14 +467,14 @@ files = [
 ]
 
 [[package]]
-name = "pyautogen"
+name = "ag2"
 version = "0.2.34"
 description = "Enabling Next-Gen LLM Applications via Multi-Agent Conversation Framework"
 optional = false
 python-versions = "<3.13,>=3.8"
 files = [
-    {file = "pyautogen-0.2.34-py3-none-any.whl", hash = "sha256:13218d2d50561249f08e75952e1aa0902982d146154f8285310977183fc829c0"},
-    {file = "pyautogen-0.2.34.tar.gz", hash = "sha256:1809bbfe2676968ccc27ee0d2312a9ba7cda50ecd8a12d4ce59fc06f618a6771"},
+    {file = "ag2-0.2.34-py3-none-any.whl", hash = "sha256:13218d2d50561249f08e75952e1aa0902982d146154f8285310977183fc829c0"},
+    {file = "ag2-0.2.34.tar.gz", hash = "sha256:1809bbfe2676968ccc27ee0d2312a9ba7cda50ecd8a12d4ce59fc06f618a6771"},
 ]
 
 [package.dependencies]

--- a/autogen-workflows/pyproject.toml
+++ b/autogen-workflows/pyproject.toml
@@ -15,7 +15,7 @@ advanced = "advanced.main:main"
 
 [tool.poetry.dependencies]
 python = ">=3.10, <3.12"
-pyautogen = "^0.2.34"
+ag2 = "^0.2.34"
 pyyaml = "^6.0.1"
 
 


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
